### PR TITLE
ball_trajectories based on hdf5 files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,16 @@ ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
 ##############
 
 if(BUILD_TESTING)
+  
+  # cpp tests
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_${PROJECT_NAME}_cpp tests/main.cpp tests/unit_tests.cpp)
   target_link_libraries(test_${PROJECT_NAME}_cpp ${PROJECT_NAME})
+
+  # python unit tests
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_${PROJECT_NAME}_python tests/unit_tests.py)
+  
 endif()
 
 

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>pam_configuration</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/python/context/__init__.py
+++ b/python/context/__init__.py
@@ -1,4 +1,3 @@
 from context_wrp import *
-from .ball_trajectories import *
 from .ball_status import BallStatus
 from .hit_point import HitPoint

--- a/python/context/ball_trajectories.py
+++ b/python/context/ball_trajectories.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import typing
 import nptyping as npt
 
-import os, random, math, pathlib, typing, h5py
+import os, random, math, pathlib, h5py
 import numpy as np
 
 import pam_configuration
@@ -73,9 +73,7 @@ def to_state_trajectory(input: StampedTrajectory) -> StateTrajectory:
     """
 
     # computing velocities by finite difference
-    t1 = input[0][:-1]
-    t2 = input[0][1:]
-    dt = (t2 - t1) * 1e-6  # also converting from us to seconds
+    dt = np.diff(input[0]) * 1e-6  # also converting from us to seconds
     positions1 = input[1][:-1, :]
     positions2 = input[1][1:, :]
     dp = positions2 - positions1
@@ -273,10 +271,10 @@ class RecordedBallTrajectories:
         """
         It is assumed that json_path is a directory hosting (non recursively)
         a collection of files named *.json. Each file host the (string) representation of
-        a dictionary with the key "obj" associated to an list of a 6d array
+        a dictionary with the key "ob" associated to an list of a 6d array
         (3d position and 3d velocities).
         This function will parse all these files and add them to the hdf5 under the specified
-        group name (or raise a FileNotFoundError if tennicam_path does not
+        group name (or raise a FileNotFoundError if json_path does not
         exists). (note: the velocities values are ignored, and the time stamp list
         is created based on the sampling rate)
         """
@@ -287,10 +285,8 @@ class RecordedBallTrajectories:
             hosts.
             """
             with open(json_file, "r") as f:
-                content = f.read()
-            content = content.strip()
-            d = eval(content)["ob"]
-            trajectory = np.array(d, np.float32)[:, :3]  # keeping only the position
+                content = json.load(f)
+            trajectory = np.array(content["ob"], np.float32)[:, :3]  # keeping only the position
             return trajectory
 
         def _read_folder(json_path: pathlib.Path) -> Trajectories:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -148,14 +148,16 @@ def test_add_trajectories(
 
     with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
         if formatting == _JSON_GROUP:
-            rbt.add_json_trajectories(
+            nb_added = rbt.add_json_trajectories(
                 group_name, working_directory, _SAMPLING_RATE * 1e6
             )
             expected_size = _NB_JSONS
         else:
-            rbt.add_tennicam_trajectories(group_name, working_directory)
+            nb_added = rbt.add_tennicam_trajectories(group_name, working_directory)
             expected_size = _NB_TENNICAMS
 
+    assert nb_added == expected_size
+            
     with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
         assert group_name in rbt.get_groups()
         assert len(rbt.get_indexes(group_name)) == expected_size

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,0 +1,200 @@
+import h5py
+import pathlib
+import pytest
+import numpy as np
+from context import ball_trajectories as bt
+
+
+# configuration of the stamped_trajectory fixture
+_START_POSITION = (1.0, 2.0, 1.0)
+_END_POSITION = (3.0, 4.0, 1.0)
+_VELOCITY = 0.5
+_SAMPLING_RATE = 0.01
+
+# configuration for working_directory fixture
+_NB_JSONS = 3
+_JSON_FILES = ["{}.json".format(i) for i in range(_NB_JSONS)]
+_JSON_GROUP = "json"
+_NB_TENNICAMS = 2
+_TENNICAM_FILES = ["tennicam_{}".format(i) for i in range(_NB_TENNICAMS)]
+_TENNICAM_GROUP = "tennicam"
+_HDF5 = "test.hdf5"
+
+
+@pytest.fixture
+def state_trajectory() -> bt.StateTrajectory:
+    """
+    Generate a line trajectory from start to end position
+    """
+    return bt.velocity_line_trajectory(
+        _START_POSITION, _END_POSITION, _VELOCITY, _SAMPLING_RATE
+    )
+
+
+@pytest.fixture
+def json_trajectory(state_trajectory: bt.StateTrajectory) -> str:
+    """
+    Convert the state trajectory to a json string representation,
+    as supported by bt.RecordedBallTrajectories.add_json_trajectories.
+    """
+
+    entries = [s.position + s.velocity for s in state_trajectory]
+    d = {"ob": entries}
+    return repr(d)
+
+
+@pytest.fixture
+def tennicam_trajectory(state_trajectory: bt.StateTrajectory) -> str:
+    """
+    create the string representation of a ball trajectory
+    in tennicam format.
+    """
+
+    size = len(state_trajectory)
+    ball_ids = [i for i in range(size)]
+    stamped_trajectory = bt.to_stamped_trajectory(state_trajectory, _SAMPLING_RATE)
+    time_stamps = stamped_trajectory[0]
+    positions = [s.position for s in state_trajectory]
+    velocities = [s.velocity for s in state_trajectory]
+    entries = [
+        (ball_id, time_stamp * 1e3, position, velocity)
+        for ball_id, time_stamp, position, velocity in zip(
+            ball_ids, time_stamps, positions, velocities
+        )
+    ]
+
+    return "\n".join([repr(e) for e in entries])
+
+
+@pytest.fixture
+def working_directory(
+    tmp_path: pathlib.Path, json_trajectory: str, tennicam_trajectory: str
+) -> pathlib.Path:
+    """
+    Generate some json and tennicam files, as well as an 
+    empty hdf5 file, in a tmp directory
+    """
+
+    jsons = [tmp_path / jf for jf in _JSON_FILES]
+
+    tennicams = [tmp_path / tf for tf in _TENNICAM_FILES]
+
+    for jf in jsons:
+        with open(jf, "w") as f:
+            f.write(json_trajectory)
+
+    for tf in tennicams:
+        with open(tf, "w") as f:
+            f.write(tennicam_trajectory)
+
+    hdf5_file = tmp_path / _HDF5
+    with h5py.File(hdf5_file, "w"):
+        pass
+
+    return tmp_path
+
+
+@pytest.fixture
+def loaded_hdf5(working_directory) -> pathlib.Path:
+    """
+    Add content to the hdf5 file present in the 
+    working directory, and returns the absolute path
+    to this file.
+    """
+
+    hdf5_file = working_directory / _HDF5
+
+    with bt.RecordedBallTrajectories(path=hdf5_file) as rbt:
+        rbt.add_json_trajectories(_JSON_GROUP, working_directory, _SAMPLING_RATE * 1e6)
+        rbt.add_tennicam_trajectories(_TENNICAM_GROUP, working_directory)
+
+    return hdf5_file
+
+
+def test_conversions(state_trajectory) -> None:
+    """
+    Test the conversions from state trajectory to 
+    stamped trajectory, and vice-versa
+    """
+
+    stamped_trajectory = bt.to_stamped_trajectory(state_trajectory, _SAMPLING_RATE)
+
+    restate_trajectory = bt.to_state_trajectory(stamped_trajectory)
+
+    for s1, s2 in zip(state_trajectory, restate_trajectory):
+        assert s1.position == s2.position
+        assert s1.velocity == pytest.approx(s2.velocity, abs=1e-3)
+
+
+@pytest.mark.parametrize("formatting", [_JSON_GROUP, _TENNICAM_GROUP])
+def test_add_trajectories(
+    working_directory: pathlib.Path,
+    state_trajectory: bt.StateTrajectory,
+    formatting: str,
+):
+    """
+    Test a hdf5 file can be updated via an instance of RecordedBallTrajectories
+    with trajectories stored in json files or tennicam files.
+    """
+
+    stamped_trajectory = bt.to_stamped_trajectory(state_trajectory, _SAMPLING_RATE)
+    ref_time_stamps = stamped_trajectory[0]
+    ref_positions = stamped_trajectory[1]
+    ref_trajectory_size = len(ref_time_stamps)
+
+    hdf5_path = working_directory / _HDF5
+
+    group_name = formatting
+
+    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+        if formatting == _JSON_GROUP:
+            rbt.add_json_trajectories(
+                group_name, working_directory, _SAMPLING_RATE * 1e6
+            )
+            expected_size = _NB_JSONS
+        else:
+            rbt.add_tennicam_trajectories(group_name, working_directory)
+            expected_size = _NB_TENNICAMS
+
+    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+        assert group_name in rbt.get_groups()
+        assert len(rbt.get_indexes(group_name)) == expected_size
+        trajectory: StampedTrajectory = rbt.get_stamped_trajectory(group_name, 0)
+        time_stamps = trajectory[0]
+        positions = trajectory[1]
+        assert time_stamps.shape == (ref_trajectory_size,)
+        assert positions.shape == (ref_trajectory_size, 3)
+        assert list(time_stamps) == pytest.approx(list(ref_time_stamps), abs=1)
+        np.testing.assert_almost_equal(trajectory[1], stamped_trajectory[1])
+
+
+@pytest.mark.parametrize("formatting", [_JSON_GROUP, _TENNICAM_GROUP])
+def test_ball_trajectories(
+    loaded_hdf5: pathlib.Path, state_trajectory: bt.StateTrajectory, formatting: str
+):
+    """
+    Test the API of BallTrajectories
+    """
+
+    if formatting == _JSON_GROUP:
+        ball_trajectories = bt.BallTrajectories(_JSON_GROUP, loaded_hdf5)
+        expected_size = _NB_JSONS
+    else:
+        ball_trajectories = bt.BallTrajectories(_TENNICAM_GROUP, loaded_hdf5)
+        expected_size = _NB_TENNICAMS
+
+    assert len(ball_trajectories.get_all_trajectories()) == expected_size
+    assert ball_trajectories.size() == expected_size
+    assert (
+        len(ball_trajectories.get_different_random_trajectories(expected_size))
+        == expected_size
+    )
+    assert len(
+        ball_trajectories.get_different_random_trajectories(expected_size - 1)
+    ) == (expected_size - 1)
+
+    stamped_trajectory = ball_trajectories.get_trajectory(0)
+    time_stamps = stamped_trajectory[0]
+    positions = stamped_trajectory[1]
+    assert time_stamps.shape == (len(state_trajectory),)
+    assert positions.shape == (len(state_trajectory), 3)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Recorded ball trajectories were assumed to be stored in json file, one trajectory per file. 

With this update, the ball trajectories will be stored in a hdf5 file. This allows to split the trajectories into groups (i.e. sets. Group is the hdf5 terminology).

There are functions to update the hdf5 file from json and tennicam files, so existing recorded trajectories can be easily added.

## How I Tested

Created and ran unit tests.

## Do not merge before

Learning table tennis from scratch, as well as some demos, will need to be updated.

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
