### PR TITLE
all method updating hdf5 file ball trajectories moved to the subclass…

### DIFF
--- a/bin/pam_ball_trajectories.py
+++ b/bin/pam_ball_trajectories.py
@@ -55,7 +55,7 @@ def _info(hdf5_path: pathlib.Path, group_name: str = None):
 
 def _add_json(hdf5_path: pathlib.Path, group_name: str, sampling: int):
     logging.info("recording trajectories in {}".format(hdf5_path))
-    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path=hdf5_path) as rbt:
         if group_name in rbt.get_groups():
             raise ValueError("group {} already present in the file")
         nb_added = rbt.add_json_trajectories(group_name, pathlib.Path.cwd(), sampling)
@@ -64,7 +64,7 @@ def _add_json(hdf5_path: pathlib.Path, group_name: str, sampling: int):
 
 def _add_tennicam(hdf5_path: pathlib.Path, group_name: str):
     logging.info("recording trajectories in {}".format(hdf5_path))
-    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path=hdf5_path) as rbt:
         if group_name in rbt.get_groups():
             raise ValueError("group {} already present in the file")
     nb_added = rbt.add_tennicam_trajectories(group_name, pathlib.Path.cwd())
@@ -72,7 +72,7 @@ def _add_tennicam(hdf5_path: pathlib.Path, group_name: str):
 
 
 def _rm_group(hdf5_path: pathlib.Path, group_name: str):
-    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path=hdf5_path) as rbt:
         rbt.rm_group(group_name)
 
 

--- a/python/context/ball_trajectories.py
+++ b/python/context/ball_trajectories.py
@@ -135,7 +135,7 @@ class RecordedBallTrajectories:
     _TIME_STAMPS = "time_stamps"
     _TRAJECTORY = "trajectory"
 
-    def __init__(self, path: pathlib.Path = None, file_mode: str = "r+"):
+    def __init__(self, path: pathlib.Path = None, file_mode: str = "r"):
         if path is None:
             path = self.get_default_path()
         self._f = h5py.File(path, file_mode)

--- a/python/context/ball_trajectories.py
+++ b/python/context/ball_trajectories.py
@@ -124,12 +124,18 @@ class RecordedBallTrajectories:
       ~/.mpi-is/pam/context/ball_trajectories.hdf5 or
       /opt/mpi-is/pam/context/ball_trajectories.hdf5
       (as installed by the pam_configuration package)
+    file_mode: (optional)
+      mode in which the h5py file will be open. The default
+      is "r" (read only), which is sufficient for all the 
+      method provided by the class. See the subclass
+      MutableRecordedBallTrajectories for methods that will
+      update the file.
     """
 
     _TIME_STAMPS = "time_stamps"
     _TRAJECTORY = "trajectory"
 
-    def __init__(self, path: pathlib.Path = None,  file_mode:str="r+"):
+    def __init__(self, path: pathlib.Path = None, file_mode: str = "r+"):
         if path is None:
             path = self.get_default_path()
         self._f = h5py.File(path, file_mode)
@@ -167,7 +173,6 @@ class RecordedBallTrajectories:
         (i.e. all the sets)
         """
         return tuple(self._f.keys())
-
 
     def get_indexes(self, group: str) -> typing.Tuple[int]:
         """
@@ -216,7 +221,6 @@ class RecordedBallTrajectories:
             for index in indexes
         }
 
-
     def close(self):
         """
         Close the hdf5 file
@@ -242,9 +246,14 @@ class RecordedBallTrajectories:
 
 
 class MutableRecordedBallTrajectories(RecordedBallTrajectories):
+    """
+    Subclass of RecordedBallTrajectories that had some method that
+    will update the content of the HDF5 file. Open the file using the
+    "r+" mode.
+    """
 
-    def __init__(self, path:pathlib.Path=None):
-        super().__init__(path,file_mode="r+")
+    def __init__(self, path: pathlib.Path = None):
+        super().__init__(path, file_mode="r+")
 
     def rm_group(self, group: str) -> None:
         """
@@ -269,7 +278,7 @@ class MutableRecordedBallTrajectories(RecordedBallTrajectories):
         positions = stamped_trajectory[1]
         traj_group.create_dataset(self._TIME_STAMPS, data=time_stamps)
         traj_group.create_dataset(self._TRAJECTORY, data=positions)
-        
+
     def add_tennicam_trajectories(
         self, group_name: str, tennicam_path: pathlib.Path
     ) -> None:
@@ -418,8 +427,7 @@ class MutableRecordedBallTrajectories(RecordedBallTrajectories):
 
         return len(trajectories)
 
-        
-        
+
 class BallTrajectories:
     """
     Convenience wrapper over a hdf5 file which contains 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -106,7 +106,7 @@ def loaded_hdf5(working_directory) -> pathlib.Path:
 
     hdf5_file = working_directory / _HDF5
 
-    with bt.RecordedBallTrajectories(path=hdf5_file) as rbt:
+    with bt.MutableRecordedBallTrajectories(path=hdf5_file) as rbt:
         rbt.add_json_trajectories(_JSON_GROUP, working_directory, _SAMPLING_RATE * 1e6)
         rbt.add_tennicam_trajectories(_TENNICAM_GROUP, working_directory)
 
@@ -120,25 +120,25 @@ def test_rm_group(loaded_hdf5) -> None:
     """
 
     path = loaded_hdf5
-    with bt.RecordedBallTrajectories(path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path) as rbt:
         assert _JSON_GROUP in rbt.get_groups()
         rbt.rm_group(_JSON_GROUP)
         assert _JSON_GROUP not in rbt.get_groups()
 
-    with bt.RecordedBallTrajectories(path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path) as rbt:
         assert _JSON_GROUP not in rbt.get_groups()
 
 
 def test_overwrite(loaded_hdf5) -> None:
     """
-    Test the RecordedBallTrajectories.overwrite 
+    Test the MutableRecordedBallTrajectories.overwrite 
     method.
     """
     stamps = np.array([10] * 5)
     positions = np.array([np.array([2] * 3)] * 5)
     path = loaded_hdf5
 
-    with bt.RecordedBallTrajectories(path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path) as rbt:
         rbt.overwrite(_JSON_GROUP, 1, (stamps, positions))
 
     with bt.RecordedBallTrajectories(path) as rbt:
@@ -202,7 +202,7 @@ def test_add_trajectories(
 
     group_name = formatting
 
-    with bt.RecordedBallTrajectories(path=hdf5_path) as rbt:
+    with bt.MutableRecordedBallTrajectories(path=hdf5_path) as rbt:
         if formatting == _JSON_GROUP:
             nb_added = rbt.add_json_trajectories(
                 group_name, working_directory, _SAMPLING_RATE


### PR DESCRIPTION
… MutableRecordedBallTrajectories

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

RecordedBallTrajectories opening by default in read only mode.
Methods updating the files moved to a new MutableRecordedBallTrajectories subclass.

## How I Tested

Ran the unit tests

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
